### PR TITLE
Allow maxSMBBasalMinutes to govern SMB size

### DIFF
--- a/lib/determine-basal/determine-basal.js
+++ b/lib/determine-basal/determine-basal.js
@@ -1042,7 +1042,7 @@ var determine_basal = function determine_basal(glucose_status, currenttemp, iob_
                 maxBolus = round( profile.current_basal * 30 / 60 ,1);
                 console.error("profile.maxSMBBasalMinutes undefined: defaulting to 30m");
             // if IOB covers more than COB, limit maxBolus to 30m of basal
-            } else if ( iob_data.iob > mealInsulinReq && iob_data.iob > 0 ) {
+            } else if (( iob_data.iob > mealInsulinReq && iob_data.iob > 0 ) && UAMduration == 0 ) {
                 console.error("IOB",iob_data.iob,"> COB",meal_data.mealCOB+"; mealInsulinReq =",mealInsulinReq);
                 maxBolus = round( profile.current_basal * 30 / 60 ,1);
             } else {


### PR DESCRIPTION
Adjust 'force 30min maxSMBBasalMinutes' so that it does not apply when UAM is active (UAMduration != 0)